### PR TITLE
Added documentation and a tiny bit of clean up.

### DIFF
--- a/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceStateUpdateEvent.java
+++ b/src/main/java/sx/blah/discord/handle/impl/events/UserVoiceStateUpdateEvent.java
@@ -1,15 +1,91 @@
 package sx.blah.discord.handle.impl.events;
 
 import sx.blah.discord.handle.Event;
-import sx.blah.discord.handle.obj.IGuild;
 import sx.blah.discord.handle.obj.IUser;
+import sx.blah.discord.handle.obj.IVoiceChannel;
 
+/**
+ * This is dispatched when the voice state of a user is updated.
+ */
 public class UserVoiceStateUpdateEvent extends Event {
-    private final IUser user;
-    private final IGuild guild;
 
-    public UserVoiceStateUpdateEvent(IUser user, IGuild guild) {
-        this.user = user;
-        this.guild = guild;
-    }
+	/**
+	 * The user that has updated.
+	 */
+	private final IUser user;
+
+	/**
+	 * The channel where this happened.
+	 */
+	private final IVoiceChannel channel;
+
+	/**
+	 * Whether or not the user was suppressed.
+	 */
+	private final boolean suppressed;
+
+	/**
+	 * Whether or not the user muted themselves. If the user did not mute
+	 * themselves, it was the server.
+	 */
+	private final boolean selfMute;
+
+	/**
+	 * Whether or not the user deafened themselves. If the user did not mute
+	 * themselves, it was the server.
+	 */
+	private final boolean selfDeafen;
+
+	public UserVoiceStateUpdateEvent(IUser user, IVoiceChannel channel, boolean selfMute, boolean selfDeafen, boolean suppress) {
+		this.user = user;
+		this.channel = channel;
+		this.selfMute = selfMute;
+		this.selfDeafen = selfDeafen;
+		this.suppressed = suppress;
+	}
+
+	/**
+	 * Retrieves the user that has had their voice status updated.
+	 * 
+	 * @return The user that had been updated.
+	 */
+	public IUser getUser() {
+		return user;
+	}
+
+	/**
+	 * Retrieves the channel where the update took place.
+	 * 
+	 * @return The voice channel where the update took place.
+	 */
+	public IVoiceChannel getChannel() {
+		return channel;
+	}
+
+	/**
+	 * Checks if the user muted themselves. If not, then it was the server.
+	 * 
+	 * @return Whether or not the user muted themselves.
+	 */
+	public boolean isSelfMuted() {
+		return selfMute;
+	}
+
+	/**
+	 * Checks if the user deafened themselves. If not, then it was the server.
+	 * 
+	 * @return Whether or not the user deafened themselves.
+	 */
+	public boolean isSelfDeafened() {
+		return selfDeafen;
+	}
+
+	/**
+	 * Checks if the user was moved to the AFK room.
+	 * 
+	 * @return Whether or not the user was moved to the AFK room.
+	 */
+	public boolean isSuppresed() {
+		return suppressed;
+	}
 }


### PR DESCRIPTION
The majority of this PR is the update of the java docs for the event. There were also some smaller changes. All of the variables were made private, to justify using getter methods. The deaf and mute fields and fields, getters and parameters were all removed, if the user did not do it themselves, then it was from the server. Changed up some of the fields, parameter and method names to get rid of all _s, they break the standard syntax.

This PR is based on local changes from lclc98 that have not yet been pushed to his fork of the project. This PR also includes several changes that break references from other classes. Given that lclc98 has not pushed all of his code yet, it is not possible to take these changes into consideration.

Side note: You better not just close this PR and include it within your local changes Liam.